### PR TITLE
Improve master data API

### DIFF
--- a/masterData/controllers.go
+++ b/masterData/controllers.go
@@ -124,3 +124,35 @@ func (ctrl *MasterDataController) BridgeOldCandidate(c *gin.Context) {
 	// 4. Return JSON
 	c.JSON(http.StatusOK, formData)
 }
+
+// --- Dictionary Endpoints ---
+
+// GetAllSkills handles GET /masterData/skills
+func (ctrl *MasterDataController) GetAllSkills(c *gin.Context) {
+	skills := GetAllMasterSkills()
+	c.JSON(http.StatusOK, skills)
+}
+
+// GetAllLanguages handles GET /masterData/languages
+func (ctrl *MasterDataController) GetAllLanguages(c *gin.Context) {
+	languages := GetAllMasterLanguages()
+	c.JSON(http.StatusOK, languages)
+}
+
+// GetAllJobTitles handles GET /masterData/jobTitles
+func (ctrl *MasterDataController) GetAllJobTitles(c *gin.Context) {
+	titles := GetAllMasterJobTitles()
+	c.JSON(http.StatusOK, titles)
+}
+
+// GetAllLocations handles GET /masterData/locations
+func (ctrl *MasterDataController) GetAllLocations(c *gin.Context) {
+	locations := GetAllMasterLocations()
+	c.JSON(http.StatusOK, locations)
+}
+
+// GetAllIndustries handles GET /masterData/industries
+func (ctrl *MasterDataController) GetAllIndustries(c *gin.Context) {
+	industries := GetAllMasterIndustries()
+	c.JSON(http.StatusOK, industries)
+}

--- a/masterData/models.go
+++ b/masterData/models.go
@@ -295,3 +295,40 @@ func convertMasterCandidateToFormData(mc models.MasterCandidate) map[string]inte
 		// etc. for all fields your form expects
 	}
 }
+
+// --- Dictionary Helpers ---
+
+// GetAllMasterSkills returns all skills from the dictionary table
+func GetAllMasterSkills() []models.MasterSkill {
+	var skills []models.MasterSkill
+	db.DB.Find(&skills)
+	return skills
+}
+
+// GetAllMasterLanguages returns all languages
+func GetAllMasterLanguages() []models.MasterLanguage {
+	var languages []models.MasterLanguage
+	db.DB.Find(&languages)
+	return languages
+}
+
+// GetAllMasterJobTitles returns all job titles
+func GetAllMasterJobTitles() []models.MasterJobTitle {
+	var titles []models.MasterJobTitle
+	db.DB.Find(&titles)
+	return titles
+}
+
+// GetAllMasterLocations returns all preferred locations
+func GetAllMasterLocations() []models.MasterLocation {
+	var locations []models.MasterLocation
+	db.DB.Find(&locations)
+	return locations
+}
+
+// GetAllMasterIndustries returns all industries
+func GetAllMasterIndustries() []models.MasterIndustry {
+	var industries []models.MasterIndustry
+	db.DB.Find(&industries)
+	return industries
+}

--- a/router/router.go
+++ b/router/router.go
@@ -25,8 +25,18 @@ func GetRouter() *gin.Engine {
 	// CORS configuration
 	config := cors.DefaultConfig()
 	config.AllowAllOrigins = true
-	config.AllowMethods = []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}
-	config.AllowHeaders = []string{"Origin", "Content-Type", "Authorization"}
+	config.AllowMethods = []string{
+		"GET",
+		"POST",
+		"PUT",
+		"DELETE",
+		"OPTIONS",
+	}
+	config.AllowHeaders = []string{
+		"Origin",
+		"Content-Type",
+		"Authorization",
+	}
 	// Apply the CORS middleware
 	Router.Use(cors.New(config))
 
@@ -60,11 +70,17 @@ func GetRouter() *gin.Engine {
 	masterDataCtrl := masterData.NewMasterDataController()
 	api.POST("/masterData/candidates", masterDataCtrl.CreateMasterCandidate)
 	api.GET("/masterData/candidates", masterDataCtrl.FindAllMasterCandidates)
+	api.GET("/masterData/candidates/numPages", masterDataCtrl.GetNumberOfPages)
 	api.GET("/masterData/candidates/:id", masterDataCtrl.FindMasterCandidateByID)
 	api.PUT("/masterData/candidates/:id", masterDataCtrl.UpdateMasterCandidate)
 	api.DELETE("/masterData/candidates/:id", masterDataCtrl.DeleteMasterCandidate)
 	api.GET("/masterData/bridge/:candidateID", masterDataCtrl.BridgeOldCandidate)
 
-	//api.GET("/masterData/locations", masterDataCtrl.GetAllMasterLocations)
+	api.GET("/masterData/skills", masterDataCtrl.GetAllSkills)
+	api.GET("/masterData/languages", masterDataCtrl.GetAllLanguages)
+	api.GET("/masterData/jobTitles", masterDataCtrl.GetAllJobTitles)
+	api.GET("/masterData/locations", masterDataCtrl.GetAllLocations)
+	api.GET("/masterData/industries", masterDataCtrl.GetAllIndustries)
+
 	return Router
 }


### PR DESCRIPTION
## Summary
- format router configuration and add master data routes
- add dictionary helper queries for master data
- expose endpoints to retrieve master dictionaries

## Testing
- `go test ./...` *(fails: forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684aa2aa0c0c8330ab80d417ce6c3497